### PR TITLE
feature/new-search

### DIFF
--- a/seotoaster_core/application/app/Helpers/Action/Cache.php
+++ b/seotoaster_core/application/app/Helpers/Action/Cache.php
@@ -40,7 +40,10 @@ class Helpers_Action_Cache extends Zend_Controller_Action_Helper_Abstract {
 
 	const CACHE_WEEK                = '604800';
 
-	protected $_cache               = null;
+    /**
+     * @var null|Zend_Cache_Core
+     */
+    protected $_cache               = null;
 
 	public function  init() {
 		$this->_cache = Zend_Registry::get('cache');

--- a/seotoaster_core/application/app/Tools/Filesystem/Tools.php
+++ b/seotoaster_core/application/app/Tools/Filesystem/Tools.php
@@ -201,4 +201,29 @@ class Tools_Filesystem_Tools {
 
 		return false;
 	}
+
+    /**
+     * Check if directory is not empty
+     * @param $dirname Directory to check
+     * @return bool true if directory empty
+     * @throws Exceptions_SeotoasterException
+     */
+    public static function isEmptyDir($dirname){
+        $dirname = trim($dirname);
+        if ($dirname == '' || !is_dir($dirname)) {
+            throw new Exceptions_SeotoasterException('Wrong directory given: ' . $dirname);
+        }
+        $handle = opendir($dirname);
+        if ($handle) {
+            while (false !== ($entry = readdir($handle))) {
+                if (!in_array($entry, array('.', '..'))) {
+                    closedir($handle);
+                    return false;
+                }
+            }
+        } else {
+            throw new Exceptions_SeotoasterException('Can not open directory: ' . $dirname);
+        }
+        return true;
+    }
 }

--- a/seotoaster_core/application/app/Tools/Search/Tools.php
+++ b/seotoaster_core/application/app/Tools/Search/Tools.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Tools
  *
@@ -7,11 +6,38 @@
  */
 class Tools_Search_Tools {
 
-	public static function renewIndex($forceCreate = false) {
-		$websiteHelper     = Zend_Controller_Action_HelperBroker::getStaticHelper('website');
-		$searchIndexFolder = $websiteHelper->getPath() . 'cache/' . Widgets_Search_Search::INDEX_FOLDER;
-		$pages             = Application_Model_Mappers_PageMapper::getInstance()->fetchAll();
+	/**
+	 * @var Zend_Search_Lucene_Interface
+	 */
+	private static $_index;
 
+	/**
+	 * Initialize search index to static property
+	 * @return Zend_Search_Lucene_Interface
+	 */
+	public static function initIndex(){
+		if (self::$_index instanceof Zend_Search_Lucene_Interface){
+			return self::$_index;
+		}
+		$searchIndexPath = Zend_Controller_Action_HelperBroker::getStaticHelper('website')->getPath() . 'cache/' . Widgets_Search_Search::INDEX_FOLDER;
+
+        if (!is_dir($searchIndexPath)) {
+            if (!Tools_Filesystem_Tools::mkDir($searchIndexPath)) {
+                Tools_System_Tools::debugMode() && error_log('Can\'t create search index folder in '.$searchIndexPath);
+            }
+        }
+
+		try {
+			self::$_index = Zend_Search_Lucene::open($searchIndexPath);
+		} catch (Exception $e) {
+			self::$_index = Zend_Search_Lucene::create($searchIndexPath);
+		}
+
+		return self::$_index;
+	}
+
+	public static function renewIndex($forceCreate = false) {
+		$pages = Application_Model_Mappers_PageMapper::getInstance()->getPagesForSearchIndex();
 		if(!is_array($pages)) {
 			return false;
 		}
@@ -21,14 +47,11 @@ class Tools_Search_Tools {
 			new Zend_Search_Lucene_Analysis_Analyzer_Common_Utf8_CaseInsensitive ()
 		);
 
-		self::removeIndex();
+		self::removeIndex() && self::initIndex();
 
-		$toasterSearchIndex = (!is_dir($searchIndexFolder) || $forceCreate) ? Zend_Search_Lucene::create($searchIndexFolder) : Zend_Search_Lucene::open($searchIndexFolder);
+		array_walk($pages, array('Tools_Search_Tools', 'addPageToIndex'));
 
-		foreach ($pages as $page) {
-			self::addPageToIndex($page, $toasterSearchIndex);
-		}
-		$toasterSearchIndex->optimize();
+		self::$_index->optimize();
 	}
 
 	public static function removeFromIndex($term) {
@@ -37,67 +60,54 @@ class Tools_Search_Tools {
 		if(!is_dir($searchIndexFolder)) {
 			return false;
 		}
-        try {
-		    $toasterSearchIndex = Zend_Search_Lucene::open($searchIndexFolder);
-        } catch (Exception $e) {
-            if(APPLICATION_ENV == 'development') {
-                error_log("(plugin: " . strtolower(get_called_class()) . ") " . $e->getMessage() . "\n" . $e->getTraceAsString());
-            }
-            return false;
-        }
-		$hits = $toasterSearchIndex->find(strval($term));
+
+		if (!self::initIndex()){
+			return false;
+		}
+
+		$hits = self::$_index->find(strval($term));
 		if(is_array($hits) && !empty ($hits)) {
 			foreach ($hits as $hit) {
-				$toasterSearchIndex->delete($hit->id);
+				self::$_index->delete($hit->id);
 			}
 			return true;
 		}
 		return false;
 	}
 
-	public static function addPageToIndex(Application_Model_Models_Page $page, $toasterSearchIndex = false) {
-		if(!$toasterSearchIndex) {
-			$websiteHelper     = Zend_Controller_Action_HelperBroker::getStaticHelper('website');
-			$searchIndexFolder = $websiteHelper->getPath() . 'cache/' . Widgets_Search_Search::INDEX_FOLDER;
-			if(!is_dir($searchIndexFolder)) {
-				return false;
-			}
-            try {
-                $toasterSearchIndex = Zend_Search_Lucene::open($searchIndexFolder);
-            } catch (Exception $e) {
-                if(APPLICATION_ENV == 'development') {
-                    error_log("(plugin: " . strtolower(get_called_class()) . ") " . $e->getMessage() . "\n" . $e->getTraceAsString());
-                }
-                return false;
-            }
+
+	public static function addPageToIndex($page, $toasterSearchIndex = false) {
+		if(!self::initIndex()) {
+			return false;
 		}
 
+		if ($page instanceof Application_Model_Models_Page) {
+			$page = $page->toArray();
 
-		$contents   = '';
-		$containers = Application_Model_Mappers_ContainerMapper::getInstance()->findByPageId($page->getId());
+			$containers = Application_Model_Mappers_ContainerMapper::getInstance()->findByPageId($page['id']);
+			$page['content'] = '';
 
-		if(!empty ($containers)) {
-			foreach ($containers as $container) {
-				$contents .= $container->getContent();
+			if(!empty ($containers)) {
+				foreach ($containers as $container) {
+					$page['content'] .= $container->getContent();
+				}
 			}
 		}
-        //@todo save contents to the cache and do not query for containers each time
 
 		$document = new Zend_Search_Lucene_Document();
-		$document->addField(Zend_Search_Lucene_Field::keyword('pageId', $page->getId()));
 
-		$document->addField(Zend_Search_Lucene_Field::unStored('metaKeyWords', $page->getMetaKeywords(), 'UTF-8'));
-		$document->addField(Zend_Search_Lucene_Field::unStored('metaDescription', $page->getMetaDescription(), 'UTF-8'));
-		$document->addField(Zend_Search_Lucene_Field::unStored('title', $page->getHeaderTitle(), 'UTF-8'));
-		$document->addField(Zend_Search_Lucene_Field::unStored('contents', $contents, 'UTF-8'));
+		$document->addField(Zend_Search_Lucene_Field::keyword('pageId', $page['id']));
+		$document->addField(Zend_Search_Lucene_Field::unStored('metaKeyWords', $page['metaKeywords'], 'UTF-8'));
+		$document->addField(Zend_Search_Lucene_Field::unStored('metaDescription', $page['metaDescription'], 'UTF-8'));
+		$document->addField(Zend_Search_Lucene_Field::unStored('headerTitle', $page['headerTitle'], 'UTF-8'));
+		$document->addField(Zend_Search_Lucene_Field::unStored('content', $page['content'], 'UTF-8'));
+		$document->addField(Zend_Search_Lucene_Field::text('teaserText', $page['teaserText'], 'UTF-8'));
+		$document->addField(Zend_Search_Lucene_Field::text('url', $page['url'], 'UTF-8'));
+		$document->addField(Zend_Search_Lucene_Field::text('navName', $page['navName'], 'UTF-8'));
+		$document->addField(Zend_Search_Lucene_Field::text('h1', $page['h1'], 'UTF-8'));
+		$document->addField(Zend_Search_Lucene_Field::text('previewImage', $page['previewImage']));
 
-		$document->addField(Zend_Search_Lucene_Field::text('pageTeaser', $page->getTeaserText(), 'UTF-8'));
-		$document->addField(Zend_Search_Lucene_Field::text('url', $page->getUrl(), 'UTF-8'));
-		$document->addField(Zend_Search_Lucene_Field::text('navName', $page->getNavName(), 'UTF-8'));
-		$document->addField(Zend_Search_Lucene_Field::text('h1', $page->getH1(), 'UTF-8'));
-
-		$document->addField(Zend_Search_Lucene_Field::binary('pageImage', base64_encode(Tools_Page_Tools::getPreview($page->getId()))));
-		$toasterSearchIndex->addDocument($document);
+		self::$_index->addDocument($document);
 	}
 
 
@@ -110,5 +120,16 @@ class Tools_Search_Tools {
 		Tools_Filesystem_Tools::deleteDir($searchIndexFolder);
 	}
 
+	public static function commit(){
+		self::initIndex()->commit();
+	}
+
+	public static function optimize(){
+		self::initIndex()->optimize();
+	}
+
+    public static function isEmpty(){
+        return (bool) self::initIndex()->numDocs() ? false : true ;
+    }
 }
 

--- a/seotoaster_core/application/app/Widgets/Search/Search.php
+++ b/seotoaster_core/application/app/Widgets/Search/Search.php
@@ -26,17 +26,21 @@ class Widgets_Search_Search extends Widgets_Abstract {
 		$this->_websiteHelper = Zend_Controller_Action_HelperBroker::getStaticHelper('website');
 
 		$this->_cacheable = false;
+        $this->_cachePrefix = strtolower(__CLASS__).'_';
+        array_push($this->_cacheTags, strtolower(__CLASS__));
 	}
 
 	protected function _load() {
 		if(!is_array($this->_options) || empty($this->_options) || !isset($this->_options[0]) || !$this->_options[0] || preg_match('~^\s*$~', $this->_options[0])) {
 			throw new Exceptions_SeotoasterWidgetException($this->_translator->translate('Not enough parameters'));
 		}
-//        $optionsArray = $this->_options;
+        $optionsArray = $this->_options;
 		$rendererName = '_renderSearch' . ucfirst(array_shift($this->_options));
 		if(method_exists($this, $rendererName)) {
 			return $this->$rendererName($this->_options);
 		}
+
+        return $this->_renderSearchComplex($optionsArray);
 	}
 
     /**
@@ -75,19 +79,43 @@ class Widgets_Search_Search extends Widgets_Abstract {
 	private function _renderSearchResults() {
         $request = Zend_Controller_Front::getInstance()->getRequest();
 
-        if (!$request->has('search')){
-            return '';
+        $params = $request->getParams();
+
+        $results = array();
+        $limit = is_numeric(end($this->_options)) ? filter_var(end($this->_options), FILTER_SANITIZE_NUMBER_INT) : self::SEARCH_LIMIT_RESULT;
+        $this->_view->useImage = (isset($this->_options[0]) && ($this->_options[0] == 'img' || $this->_options[0] == 'imgc')) ? $this->_options[0] : false;
+
+        if ($request->has('search')) {
+            $searchTerm = filter_var($request->getParam('search'), FILTER_SANITIZE_STRING);
+            $this->_view->urlData = array('search' => $searchTerm);
+            $results = $this->_searchResultsByTerm($searchTerm);
+        } elseif ($request->has('queryID')) {
+            $queryID = filter_var($request->getParam('queryID'), FILTER_SANITIZE_STRING);
+            $this->_view->urlData = array('queryID' => $queryID);
+            $results = $this->_searchResultsByQueryID($queryID);
         }
 
-        $limit = is_numeric(end($this->_options)) ? filter_var(end($this->_options), FILTER_SANITIZE_NUMBER_INT) : self::SEARCH_LIMIT_RESULT;
+        if (is_array($results) && empty($results) ){
+            return '{$content:nothingfound}';
+        }
+
+        $pager = Zend_Paginator::factory($results);
+        $pager->setDefaultItemCountPerPage($limit);
+        if (isset($params['showpage'])){
+            $pager->setCurrentPageNumber(filter_var($params['showpage'], FILTER_SANITIZE_NUMBER_INT));
+        }
+        $this->_view->pager = $pager;
+
+        return $this->_view->render('results.phtml');
+    }
+
+    private function _searchResultsByTerm($searchTerm){
 
         $searchForm = new Application_Form_Search();
 
-        $searchTerm = filter_var($request->getParam('search'), FILTER_SANITIZE_STRING);
-
         if ($searchForm->getElement('search')->isValid($searchTerm)){
             $searchTerm = $searchForm->getElement('search')->getValue();
-            $this->_view->searchTerm = $searchTerm;
+            $this->_view->pagerData = array('search' => $searchTerm);
             $searchTerm = trim($searchTerm, '*') . '*';
             if (null === ($searchResults = $this->_cache->load($searchTerm, strtolower(__CLASS__)))){
                 $toasterSearchIndex = Tools_Search_Tools::initIndex();
@@ -106,52 +134,82 @@ class Widgets_Search_Search extends Widgets_Abstract {
 
                 $this->_cache->save($searchTerm, $searchResults, strtolower(__CLASS__), array('search'), Helpers_Action_Cache::CACHE_LONG);
             }
-            if (empty($searchResults)) {
-                return '{$content:nothingfound}';
-            } else {
-                $totalHits = count($searchResults);
-                $pager = Zend_Paginator::factory($searchResults);
-                $pager->setDefaultItemCountPerPage($limit);
-                if ($request->has('showpage')){
-                    $pager->setCurrentPageNumber(filter_var($request->getParam('showpage'), FILTER_SANITIZE_NUMBER_INT));
-                }
-                if ($totalHits > $limit){
-                    $this->_view->showMore = true;
-                    $this->_view->limit = $limit;
-                    $searchResults = array_slice($searchResults, 0, $limit);
-                }
-                $this->_view->hits = $searchResults;
-                $this->_view->pager = $pager;
-            }
+            return $searchResults;
         } else {
-            // TODO $searchTerm validation error
             $msg = $searchForm->getElement('search')->getMessages();
+            $error = $this->_translator->translate('Search error. '. implode(PHP_EOL, $msg));
+            throw new Exceptions_SeotoasterWidgetException($error);
+        }
+    }
 
-            return $this->_translator->translate('Search error. '. implode(PHP_EOL, $msg));
+	private function _searchResultsByQueryID($queryID) {
+        $this->_cachePrefix .= 'qid_';
+        if (null === ($results = $this->_cache->load($queryID, $this->_cachePrefix))){
+            $results = array();
+            /**
+             * @var $flashHelper Zend_Controller_Action_Helper_FlashMessenger
+             */
+            $flashHelper = Zend_Controller_Action_HelperBroker::getStaticHelper('FlashMessenger');
+            $msgBuffer = $flashHelper->getMessages($queryID);
+
+            if (!empty($msgBuffer)) {
+                $nameValuePairs = $msgBuffer[0];
+                unset($msgBuffer);
+
+                $pageIDs = Application_Model_Mappers_ContainerMapper::getInstance()->findByContainerNameWithContent($nameValuePairs);
+                if(!empty($pageIDs)){
+                    // TODO: compare performance
+//                    $pageList = Application_Model_Mappers_PageMapper::getInstance()->find($containerData);
+                    $pageMapper = Application_Model_Mappers_PageMapper::getInstance();
+                    $where = $pageMapper->getDbTable()->getAdapter()->quoteInto('id IN (?)', array_values($pageIDs));
+                    $pages = $pageMapper->fetchAll($where);
+                    foreach ($pages as $page) {
+                        if ($page->getDraft()) {
+                            continue;
+                        }
+
+                        if ((bool)$page->getPreviewImage()) {
+                            $previewImage = Tools_Page_Tools::getPreview($page);
+                        } else {
+                            $previewImage = '';
+                        }
+
+                        array_push($this->_cacheTags, 'pageid_'.$page->getId());
+                        $results[] = array(
+                            'pageId'       => $page->getId(),
+                            'url'          => $page->getUrl(),
+                            'h1'           => $page->getH1(),
+                            'teaserText'   => $page->getTeaserText(),
+                            'navName'      => $page->getNavName(),
+                            'previewImage' => $previewImage
+                        );
+                    }
+                }
+            }
+            $this->_cache->save($queryID, $results, $this->_cachePrefix, $this->_cacheTags, Helpers_Action_Cache::CACHE_WEEK);
         }
 
-        $this->_view->useImage = (isset($this->_options[0]) && ($this->_options[0] == 'img' || $this->_options[0] == 'imgc')) ? $this->_options[0] : false;
+        return $results;
+    }
 
-		return $this->_view->render('results.phtml');
-	}
-
-	public static function getWidgetMakerContent() {
-		$translator = Zend_Registry::get('Zend_Translate');
-		$view = new Zend_View(array(
-			'scriptPath' => dirname(__FILE__) . '/views'
-		));
-		$websiteHelper = Zend_Controller_Action_HelperBroker::getStaticHelper('website');
-		$data = array(
-			'title'   => $translator->translate('Search engine'),
-			'content' => $view->render('wmcontent.phtml'),
-			'icons'   => array(
-				$websiteHelper->getUrl() . 'system/images/widgets/search.png',
-			)
-		);
-
-		unset($view);
-		return $data;
-	}
+//   // removed in current version
+//    public static function getWidgetMakerContent() {
+//		$translator = Zend_Registry::get('Zend_Translate');
+//		$view = new Zend_View(array(
+//			'scriptPath' => dirname(__FILE__) . '/views'
+//		));
+//		$websiteHelper = Zend_Controller_Action_HelperBroker::getStaticHelper('website');
+//		$data = array(
+//			'title'   => $translator->translate('Search engine'),
+//			'content' => $view->render('wmcontent.phtml'),
+//			'icons'   => array(
+//				$websiteHelper->getUrl() . 'system/images/widgets/search.png',
+//			)
+//		);
+//
+//		unset($view);
+//		return $data;
+//	}
 
     private function _renderSearchComplex($optionsArray){
         if(isset($optionsArray[0])){
@@ -160,17 +218,12 @@ class Widgets_Search_Search extends Widgets_Abstract {
             }else{
                 $prepopSearchName = $optionsArray[0];
             }
-            $prepopWithNameList = Application_Model_Mappers_ContainerMapper::getInstance()->findByContainerName($prepopSearchName);
+            $prepopWithNameList = Application_Model_Mappers_ContainerMapper::getInstance()->findByContainerName($prepopSearchName, true);
             if($prepopWithNameList){
-                $this->_view->prepopWithName = $prepopWithNameList;
-                foreach($prepopWithNameList as $prepopData){
-                    $contentArray[] = $prepopData->getContent();
-                }
-                asort($contentArray);
-                $this->_view->prepopWithNameList = array_unique($contentArray);
+                $this->_view->prepopName = $prepopSearchName;
+                $this->_view->prepopWithNameList = $prepopWithNameList;
                 return $this->_view->render('searchForm.phtml');
             }
-
         }
     }
 
@@ -189,21 +242,21 @@ class Widgets_Search_Search extends Widgets_Abstract {
     }
 
     private function _renderSearchLinks($optionsArray){
-        if(isset($optionsArray[0]) && isset($optionsArray[1])){
+        if(isset($optionsArray[0])){
             $containerMapper = Application_Model_Mappers_ContainerMapper::getInstance();
             $this->_view->addHelperPath('ZendX/JQuery/View/Helper/', 'ZendX_JQuery_View_Helper');
-            if(strtolower($optionsArray[1]) != 'thispage'){
-                $prepopAllLinks = $containerMapper->findByContainerName($optionsArray[1], true);
+            if(strtolower($optionsArray[0]) != 'thispage'){
+                $prepopAllLinks = $containerMapper->findByContainerName($optionsArray[0], true);
                 if(!empty($prepopAllLinks)){
                     foreach($prepopAllLinks as $prepopData){
                         $contentArray[] = $prepopData['content'];
                     }
                     asort($contentArray);
-                    $this->_view->prepopName = $optionsArray[1];
+                    $this->_view->prepopName = $optionsArray[0];
                     $this->_view->prepopLinks = $contentArray;
                     return $this->_view->render('links.phtml');
                 }
-            }else{
+            } else {
                 $prepopPageLinks = $containerMapper->findPreposByPageId($this->_toasterOptions['id']);
                 if(!empty($prepopPageLinks)){
                     $this->_view->prepopPageLinks = $prepopPageLinks;
@@ -213,41 +266,59 @@ class Widgets_Search_Search extends Widgets_Abstract {
         }
     }
 
-    private function _renderSearchAdvanced($optionsArray){
-        if(isset($optionsArray[1]) && preg_match('~\|~', $optionsArray[1]) && isset($optionsArray[2])){
-            $cacheHelper = Zend_Controller_Action_HelperBroker::getStaticHelper('cache');
+    private function _renderSearchAdvanced(){
+        $this->_cachePrefix .= 'advanced_';
+        if (is_array($this->_options) && !empty($this->_options)) {
             $prepopWithQuantity = array();
             $prepopLabels = array();
-            $prepopNames = explode('|', $optionsArray[1]);
+            $prepopNames = explode('|', $this->_options[0]);
             foreach($prepopNames as $key => $prepopName){
-                if(preg_match('(#)', $prepopName)){
+                if (mb_strpos($prepopName, '(#)') !== false){
                     $prepopWithQuantity[] = str_replace('(#)','',$prepopName);
                     $prepopNames[$key] = str_replace('(#)','',$prepopName);
                 }
             }
-            if(isset($optionsArray[2]) && preg_match('~\|~', $optionsArray[2])){
-                $prepopLabels =  explode('|', $optionsArray[2]);
+            if (isset($this->_options[1]) && mb_strpos($this->_options[1], '|') !== false) {
+                $prepopLabels = explode('|', $this->_options[1]);
             }
-            if(count($prepopNames) == count($prepopLabels)){
+            if (count($prepopNames) == count($prepopLabels)) {
                 $prepopLabels = array_combine($prepopNames, $prepopLabels);
             }
 
-            if(end($optionsArray) == 'select'){
-                $cacheKey = str_replace('(#)','_',$optionsArray[1]);
-                if (null === ($prepopSearchData = $cacheHelper->load('search_prepop_'.$cacheKey, 'search_prepop'))){
+            if (end($this->_options) === 'select') {
+                $cacheKey = str_replace('(#)','N',$this->_options[0]);
+                if (null === ($prepopSearchData = $this->_cache->load($cacheKey, $this->_cachePrefix))) {
                     $prepopWithNameList = Application_Model_Mappers_ContainerMapper::getInstance()->findByContainerNames($prepopNames);
-                    if(!empty($prepopWithNameList)){
-                        foreach($prepopWithNameList as $prepopWithName){
-                            $searchArray[$prepopWithName->getPageId()][$prepopWithName->getName()] = $prepopWithName->getContent();
-                            $prepopNamePageIds[$prepopWithName->getName()][$prepopWithName->getContent()][$prepopWithName->getPageId()] = $prepopWithName->getPageId();
-                            $prepopNameValues[$prepopWithName->getName()][$prepopWithName->getContent()]['content'] = $prepopWithName->getContent();
-                            if(isset($prepopNameValues[$prepopWithName->getName()][$prepopWithName->getContent()]['content']) && $prepopNameValues[$prepopWithName->getName()][$prepopWithName->getContent()]['content'] == $prepopWithName->getContent()){
-                                $prepopNameValues[$prepopWithName->getName()][$prepopWithName->getContent()]['quantity'] = $prepopNameValues[$prepopWithName->getName()][$prepopWithName->getContent()]['quantity'] + 1;
+                    if (!empty($prepopWithNameList)) {
+                        foreach ($prepopWithNameList as $prepopWithName) {
+                            //adding cache tags
+                            array_push($this->_cacheTags, $prepopWithName['name'].'_'.$prepopWithName['container_type'].'_pid_'.$prepopWithName['page_id']);
+                            $searchArray[$prepopWithName['page_id']][$prepopWithName['name']] = $prepopWithName['content'];
+                            $prepopNamePageIds[$prepopWithName['name']][$prepopWithName['content']][$prepopWithName['page_id']] = $prepopWithName['page_id'];
+                            $prepopNameValues[$prepopWithName['name']][$prepopWithName['content']]['content'] = $prepopWithName['content'];
+                            if (isset($prepopNameValues[$prepopWithName['name']][$prepopWithName['content']]['content'])
+                                    && $prepopNameValues[$prepopWithName['name']][$prepopWithName['content']]['content'] == $prepopWithName['content']
+                            ) {
+                                if (!isset($prepopNameValues[$prepopWithName['name']][$prepopWithName['content']]['quantity'])) {
+                                    $prepopNameValues[$prepopWithName['name']][$prepopWithName['content']]['quantity'] = 0;
+                                }
+                                $prepopNameValues[$prepopWithName['name']][$prepopWithName['content']]['quantity'] += 1;
                             }
                         }
                     }
-                    $prepopSearchData = array('searchArray'=>$searchArray, 'prepopNamePageIds'=>$prepopNamePageIds, 'prepopNameValues'=>$prepopNameValues);
-                    $cacheHelper->save('search_prepop_'.$cacheKey, $prepopSearchData, 'search_prepop', array(), Helpers_Action_Cache::CACHE_SHORT);
+                    $prepopSearchData = array(
+                        'searchArray' => $searchArray,
+                        'prepopNamePageIds' => $prepopNamePageIds,
+                        'prepopNameValues' => $prepopNameValues
+                    );
+                    //saving to cache
+                    $this->_cache->save(
+                        $cacheKey,
+                        $prepopSearchData,
+                        $this->_cachePrefix,
+                        array_unique($this->_cacheTags),
+                        Helpers_Action_Cache::CACHE_NORMAL
+                    );
                 }
                 $this->_view->addHelperPath('ZendX/JQuery/View/Helper/', 'ZendX_JQuery_View_Helper');
                 $this->_view->prepopNames = $prepopNames;
@@ -274,13 +345,17 @@ class Widgets_Search_Search extends Widgets_Abstract {
 				'option' => 'search:select:change_to_the_your_prepop_name'
 			),
 			array(
-				'alias'  => $translator->translate('Prepop seacrh button'),
+				'alias'  => $translator->translate('Prepop search button'),
 				'option' => 'search:button'
 			),
             array(
 				'alias'  => $translator->translate('Search form'),
 				'option' => 'search:form'
-			)
+			),
+            array(
+                'alias'  => $translator->translate('Search results'),
+                'option' => 'search:results'
+            )
         );
     }
 }

--- a/seotoaster_core/application/app/Widgets/Search/views/form.phtml
+++ b/seotoaster_core/application/app/Widgets/Search/views/form.phtml
@@ -3,29 +3,3 @@
     <?php echo $this->searchForm->getElement('search'); ?>
     <p><input type="submit" value="<?php echo $this->translate('Search'); ?>"/></p>
 </form>
-<?php if(isset($this->runIndexing)): ?>
-<script type="text/javascript">
-	if (!window.Toastr){
-	    window.Toastr = {};
-	}
-
-	if (!$('#toasterSearchIndex').size()){
-		$('#logoutul').before('<div id="toasterSearchIndex">' +
-				'<span></span>&nbsp;<img src="/system/images/ajax-loader-small.gif" alt=""/></div>');
-	}
-
-	Toastr.renewIndex = function(params){
-		$('#toasterSearchIndex span').html('<?php echo $this->translate('Building search index'); ?>');
-		$.post($('#website_url').val() + 'backend/search/reindex/', params).done(function(data, status, xhr){
-			console.log(data);
-			if (status === "success" && data) {
-				Toastr.renewIndex(data);
-			} else {
-				$('#toasterSearchIndex').slideDown().delay(1000).remove();
-			}
-		});
-	}
-
-//	$(function(){ window.Toastr && Toastr.renewIndex(); });
-</script>
-<?php endif; ?>

--- a/seotoaster_core/application/app/Widgets/Search/views/form.phtml
+++ b/seotoaster_core/application/app/Widgets/Search/views/form.phtml
@@ -1,11 +1,31 @@
-<?php echo $this->searchForm; ?>
-<?php //if($this->renewIndex): ?>
-<!--    <script type="text/javascript">-->
-<!--        $('#logoutul li a').one('click', function(e) {-->
-<!--            e.preventDefault();-->
-<!--            $.post('--><?php //echo $this->_websiteUrl;?><!--backend/search/managesearchindex/', {doaction: 'renew'}, function() {-->
-<!--                window.location.href = --><?php //echo $this->_websiteUrl;?><!--'backend/login/logout/';-->
-<!--            });-->
-<!--        });-->
-<!--    </script>-->
-<?php //endif; ?>
+<form id="<?php echo $this->searchForm->getAttrib('id'); ?>" action="<?php echo $this->searchForm->getAction(); ?>"
+      method="<?php echo $this->searchForm->getMethod(); ?>">
+    <?php echo $this->searchForm->getElement('search'); ?>
+    <p><input type="submit" value="<?php echo $this->translate('Search'); ?>"/></p>
+</form>
+<?php if(isset($this->runIndexing)): ?>
+<script type="text/javascript">
+	if (!window.Toastr){
+	    window.Toastr = {};
+	}
+
+	if (!$('#toasterSearchIndex').size()){
+		$('#logoutul').before('<div id="toasterSearchIndex">' +
+				'<span></span>&nbsp;<img src="/system/images/ajax-loader-small.gif" alt=""/></div>');
+	}
+
+	Toastr.renewIndex = function(params){
+		$('#toasterSearchIndex span').html('<?php echo $this->translate('Building search index'); ?>');
+		$.post($('#website_url').val() + 'backend/search/reindex/', params).done(function(data, status, xhr){
+			console.log(data);
+			if (status === "success" && data) {
+				Toastr.renewIndex(data);
+			} else {
+				$('#toasterSearchIndex').slideDown().delay(1000).remove();
+			}
+		});
+	}
+
+//	$(function(){ window.Toastr && Toastr.renewIndex(); });
+</script>
+<?php endif; ?>

--- a/seotoaster_core/application/app/Widgets/Search/views/pager.phtml
+++ b/seotoaster_core/application/app/Widgets/Search/views/pager.phtml
@@ -1,0 +1,42 @@
+<?php $url = $this->serverUrl().$this->url() . '?'; ?>
+<?php if ($this->pageCount > 1): ?>
+<div class="paginator">
+<?php if ($this->current !== $this->first) :?>
+    <a class="page" href="<?php echo $url.http_build_query(array('search' => $this->searchTerm)); ?>">&laquo; First</a>
+<?php endif; ?>
+
+<!-- Previous page link -->
+<?php if (isset($this->previous)): ?>
+  <a class="page" href="<?php echo $url.http_build_query(array('search' => $this->searchTerm, 'showpage' => $this->previous)); ?>">
+      &lsaquo; Previous
+  </a>
+<?php else: ?>
+  <span class="page selected">&lsaquo; Previous</span>
+<?php endif; ?>
+ 
+<!-- Numbered page links -->
+<?php foreach ($this->pagesInRange as $page): ?>
+  <?php if ($page != $this->current): ?>
+    <a href="<?php echo $url.http_build_query(array('search' => $this->searchTerm, 'showpage' => $page)); ?>">
+        <?php echo $page; ?>
+    </a>
+  <?php else: ?>
+    <?php echo $page; ?>
+  <?php endif; ?>
+<?php endforeach; ?>
+ 
+<!-- Next page link -->
+<?php if (isset($this->next)): ?>
+  <a href="<?php echo $url.http_build_query(array('search' => $this->searchTerm, 'showpage' => $this->next)); ?>">
+    Next &rsaquo;
+  </a>
+<?php else: ?>
+  <span class="page selected">Next &rsaquo;</span>
+<?php endif; ?>
+
+<?php if ($this->current !== $this->last) :?>
+    <a class="page" href="<?php echo $url.http_build_query(array('search' => $this->searchTerm, 'showpage'=>$this->last)); ?>">Last &raquo;</a>
+<?php endif; ?>
+
+</div>
+<?php endif; ?>

--- a/seotoaster_core/application/app/Widgets/Search/views/pager.phtml
+++ b/seotoaster_core/application/app/Widgets/Search/views/pager.phtml
@@ -2,12 +2,12 @@
 <?php if ($this->pageCount > 1): ?>
 <div class="paginator">
 <?php if ($this->current !== $this->first) :?>
-    <a class="page" href="<?php echo $url.http_build_query(array('search' => $this->searchTerm)); ?>">&laquo; First</a>
+    <a class="page" href="<?php echo $url.http_build_query($this->urlData); ?>">&laquo; First</a>
 <?php endif; ?>
 
 <!-- Previous page link -->
 <?php if (isset($this->previous)): ?>
-  <a class="page" href="<?php echo $url.http_build_query(array('search' => $this->searchTerm, 'showpage' => $this->previous)); ?>">
+  <a class="page" href="<?php echo $url.http_build_query(array_merge($this->urlData, array('showpage' => $this->previous))); ?>">
       &lsaquo; Previous
   </a>
 <?php else: ?>
@@ -17,7 +17,7 @@
 <!-- Numbered page links -->
 <?php foreach ($this->pagesInRange as $page): ?>
   <?php if ($page != $this->current): ?>
-    <a href="<?php echo $url.http_build_query(array('search' => $this->searchTerm, 'showpage' => $page)); ?>">
+    <a href="<?php echo $url.http_build_query(array_merge($this->urlData,  array('showpage' => $page))); ?>">
         <?php echo $page; ?>
     </a>
   <?php else: ?>
@@ -27,7 +27,7 @@
  
 <!-- Next page link -->
 <?php if (isset($this->next)): ?>
-  <a href="<?php echo $url.http_build_query(array('search' => $this->searchTerm, 'showpage' => $this->next)); ?>">
+  <a href="<?php echo $url.http_build_query(array_merge($this->urlData, array('showpage' => $this->next))); ?>">
     Next &rsaquo;
   </a>
 <?php else: ?>
@@ -35,7 +35,7 @@
 <?php endif; ?>
 
 <?php if ($this->current !== $this->last) :?>
-    <a class="page" href="<?php echo $url.http_build_query(array('search' => $this->searchTerm, 'showpage'=>$this->last)); ?>">Last &raquo;</a>
+    <a class="page" href="<?php echo $url.http_build_query(array_merge($this->urlData, array('showpage'=>$this->last))); ?>">Last &raquo;</a>
 <?php endif; ?>
 
 </div>

--- a/seotoaster_core/application/app/Widgets/Search/views/results.phtml
+++ b/seotoaster_core/application/app/Widgets/Search/views/results.phtml
@@ -18,4 +18,4 @@
 </ul>
 <?php endif; ?>
 
-<?php echo $this->paginationControl($this->pager, 'Elastic', 'pager.phtml', array('searchTerm' => $this->searchTerm)); ?>
+<?php echo $this->paginationControl($this->pager, 'Elastic', 'pager.phtml', array('urlData' => $this->urlData)); ?>

--- a/seotoaster_core/application/app/Widgets/Search/views/results.phtml
+++ b/seotoaster_core/application/app/Widgets/Search/views/results.phtml
@@ -1,51 +1,21 @@
-<?php if(is_array($this->hits) && !empty($this->hits)): ?>
-	<ul class="search-results">
-        <?php foreach ($this->hits as $hit): ?>
-            <li class="search-result-row">
-                <?php if ($this->useImage): ?>
-                    <a class="page-teaser-image" href="<?php echo $hit['url']; ?>" title="<?php echo $hit['h1']; ?>">
-                        <img src="<?php echo $this->escape(
-                            !empty($hit['pagePreview']) ? $hit['pagePreview'] : Tools_Page_Tools::getPreview($hit['pageId'])
-                        ); ?>" alt="<?php echo $hit['h1']; ?>" />
-                    </a>
-                <?php endif; ?>
-                <a href="<?php echo $hit['url']; ?>" title="<?php echo $hit['h1']; ?>" class="page-title">
-                    <?php echo $hit['navName']; ?>
-                </a>
-				<span>
-					<?php echo $hit['pageTeaser']; ?>
-				</span>
-            </li>
-        <?php endforeach; ?>
-	</ul>
-    <?php if ($this->totalHits > $this->limit): ?>
-        <a href="javascript:;" class="search-show-more" data-limit="<?php echo $this->limit; ?>"
-           data-img="<?php echo $this->useImage; ?>">
-            <?php echo $this->translate('show more'); ?>
+<?php if (count($this->pager)): ?>
+<ul class="search-results">
+<?php foreach ($this->pager as $hit): ?>
+    <li class="search-result-row">
+        <?php if ($this->useImage): ?>
+            <a class="page-teaser-image" href="<?php echo $hit['url']; ?>" title="<?php echo $hit['h1']; ?>">
+                <img src="<?php echo $this->escape(
+                    !empty($hit['previewImage']) ? $hit['previewImage'] : Tools_Page_Tools::getPreview($hit['pageId'])
+                ); ?>" alt="<?php echo $hit['h1']; ?>" />
+            </a>
+        <?php endif; ?>
+        <a href="<?php echo $hit['url']; ?>" title="<?php echo $hit['h1']; ?>" class="page-title">
+            <?php echo $hit['navName']; ?>
         </a>
-    <?php endif; ?>
-<?php else: ?>
-	<?php echo $this->hits; ?>
+        <span><?php echo $hit['teaserText']; ?></span>
+    </li>
+<?php endforeach; ?>
+</ul>
 <?php endif; ?>
 
-<script type="text/javascript">
-    $('.search-show-more').on('click', function(e){
-        var self = this;
-        e.preventDefault();
-        showSpinner();
-        $.ajax({
-            type: "POST",
-            url: '<?php echo $this->websiteUrl;?>backend/search/showmoreresults/',
-            dataType: "json",
-            data: $(self).data(),
-            success: function(response){
-                hideSpinner();
-                if (!response.error || !response.responseText.moreResults) {
-                    $(self).replaceWith('<span id="search-show-nomore"><?php echo $this->translate('No more results found'); ?></span>');
-                } else {
-                    $(self).prev('ul.search-results').append(response.responseText.searchResultsData);
-                }
-            }
-        });
-    });
-</script>
+<?php echo $this->paginationControl($this->pager, 'Elastic', 'pager.phtml', array('searchTerm' => $this->searchTerm)); ?>

--- a/seotoaster_core/application/app/Widgets/Search/views/results.phtml
+++ b/seotoaster_core/application/app/Widgets/Search/views/results.phtml
@@ -1,49 +1,49 @@
 <?php if(is_array($this->hits) && !empty($this->hits)): ?>
 	<ul class="search-results">
-		<?php foreach($this->hits as $hit): ?>
-			<li class="search-result-row">
-				<?php if($this->useImage): ?>
-					<a class="page-teaser-image" href="<?php echo $hit['url']; ?>" title="<?php echo $hit['h1']; ?>">
-						<img src="<?php echo $this->escape(!empty($hit['preview']) ? $hit['preview'] : Tools_Page_Tools::getPreview($hit['pageId'])); ?>" alt="<?php echo $hit['h1']; ?>" />
-					</a>
-				<?php endif; ?>
-				<a href="<?php echo $hit['url']; ?>" title="<?php echo $hit['h1']; ?>" class="page-title"><?php echo $hit['navName']; ?></a>
+        <?php foreach ($this->hits as $hit): ?>
+            <li class="search-result-row">
+                <?php if ($this->useImage): ?>
+                    <a class="page-teaser-image" href="<?php echo $hit['url']; ?>" title="<?php echo $hit['h1']; ?>">
+                        <img src="<?php echo $this->escape(
+                            !empty($hit['pagePreview']) ? $hit['pagePreview'] : Tools_Page_Tools::getPreview($hit['pageId'])
+                        ); ?>" alt="<?php echo $hit['h1']; ?>" />
+                    </a>
+                <?php endif; ?>
+                <a href="<?php echo $hit['url']; ?>" title="<?php echo $hit['h1']; ?>" class="page-title">
+                    <?php echo $hit['navName']; ?>
+                </a>
 				<span>
 					<?php echo $hit['pageTeaser']; ?>
 				</span>
-			</li>
-		<?php endforeach; ?>
+            </li>
+        <?php endforeach; ?>
 	</ul>
-    <?php if ($this->totalResults >= $this->limit): ?>
-        <input type="hidden" name="searchLimit" id="searchLimit" value="<?php echo $this->limit;?>"/>
-        <input type="hidden" name="searchUseImage" id="searchUseImage" value="<?php echo $this->useImage;?>"/>
-        <a href="javascript:;" class="search-show-more"><?php echo $this->translate('show more'); ?></a>
+    <?php if ($this->totalHits > $this->limit): ?>
+        <a href="javascript:;" class="search-show-more" data-limit="<?php echo $this->limit; ?>"
+           data-img="<?php echo $this->useImage; ?>">
+            <?php echo $this->translate('show more'); ?>
+        </a>
     <?php endif; ?>
 <?php else: ?>
 	<?php echo $this->hits; ?>
 <?php endif; ?>
 
-<script>
+<script type="text/javascript">
     $('.search-show-more').on('click', function(e){
+        var self = this;
         e.preventDefault();
         showSpinner();
         $.ajax({
             type: "POST",
             url: '<?php echo $this->websiteUrl;?>backend/search/showmoreresults/',
             dataType: "json",
-            data: {
-                searchLimit:$('#searchLimit').val(),
-                searchUseImage:$('#searchUseImage').val()
-            },
+            data: $(self).data(),
             success: function(response){
                 hideSpinner();
-                if(response.error == 0){
-                   $('.search-results').append(response.responseText.searchResultsData);
-                   if(response.responseText.moreResults == 0){
-                       $('.search-show-more').replaceWith('<span id="search-show-nomore"><?php echo $this->translate('No more results found'); ?></span>');
-                   }
-                }else{
-                   $('.search-show-more').replaceWith('<span id="search-show-nomore"><?php echo $this->translate('No more results found'); ?></span>');
+                if (!response.error || !response.responseText.moreResults) {
+                    $(self).replaceWith('<span id="search-show-nomore"><?php echo $this->translate('No more results found'); ?></span>');
+                } else {
+                    $(self).prev('ul.search-results').append(response.responseText.searchResultsData);
                 }
             }
         });

--- a/seotoaster_core/application/app/Widgets/Search/views/searchButton.phtml
+++ b/seotoaster_core/application/app/Widgets/Search/views/searchButton.phtml
@@ -1,6 +1,7 @@
-<input type="button" name="searchButton" class="searchButton" value="Search"/>
+<?php $formId = uniqid('search-btn-'); ?>
+<input id="<?php echo $formId; ?>" type="button" name="searchButton" class="searchButton" value="Search"/>
 <script type="text/javascript">
-    $(document).on('click', '.searchButton', function() {
+    $('#<?php echo $formId; ?>').on('click', function() {
         var urlAction = "<?php echo $this->websiteUrl; ?>backend/search/complexSearch/";
         var searchValues = [];
         var containerNames = [];

--- a/seotoaster_core/application/app/Widgets/Search/views/searchForm.phtml
+++ b/seotoaster_core/application/app/Widgets/Search/views/searchForm.phtml
@@ -1,7 +1,7 @@
-<select class="searchParams" name="<?php echo $this->prepopWithName[0]->getName();?>">
+<select class="searchParams" name="<?php echo $this->prepopName;?>">
 <option value="select"><?php echo $this->translate('select');?></option>
 <?php foreach($this->prepopWithNameList as $prepopName):?>
-    <option value="<?php echo $prepopName;?>"><?php echo $prepopName;?></option>
+    <option value="<?php echo $prepopName['content'];?>"><?php echo $prepopName['content'];?></option>
 <?php endforeach; ?>
 </select>
 

--- a/seotoaster_core/application/app/Widgets/Search/views/searchForm.phtml
+++ b/seotoaster_core/application/app/Widgets/Search/views/searchForm.phtml
@@ -1,7 +1,7 @@
 <select class="searchParams" name="<?php echo $this->prepopName;?>">
 <option value="select"><?php echo $this->translate('select');?></option>
-<?php foreach($this->prepopWithNameList as $prepopName):?>
-    <option value="<?php echo $prepopName['content'];?>"><?php echo $prepopName['content'];?></option>
+<?php foreach($this->prepopWithNameList as $prepop):?>
+    <option value="<?php echo $prepop['content'];?>"><?php echo $prepop['content'];?></option>
 <?php endforeach; ?>
 </select>
 

--- a/seotoaster_core/application/controllers/SearchController.php
+++ b/seotoaster_core/application/controllers/SearchController.php
@@ -111,6 +111,19 @@ class SearchController extends Zend_Controller_Action {
             }
         }
         $containerContentArray = array_combine($containersNames, $searchValues);
+        $queryID = md5(serialize($containerContentArray));
+        $this->_helper->flashMessenger->addMessage($containerContentArray, $queryID);
+
+        echo json_encode(
+            array(
+                'redirect' => $this->_helper->website->getUrl() . $redirectPage . '?' . http_build_query(
+                            array('queryID' => $queryID)
+                        )
+            )
+        );
+
+        return;
+
         $containerData = Application_Model_Mappers_ContainerMapper::getInstance()->findByContainerNameWithContent($containerContentArray);
         $findUrlList = array();
         if(!empty($containerData)){
@@ -135,7 +148,13 @@ class SearchController extends Zend_Controller_Action {
         }else {
             $this->_helper->session->searchHits = '{$content:nothingfound}';
         }
-        echo json_encode(array('redirect'=>$this->_helper->website->getUrl() . $redirectPage));
+        echo json_encode(
+            array(
+                'redirect' => $this->_helper->website->getUrl() . $redirectPage . '?' . http_build_query(
+                            array('queryID' => $queryID)
+                        )
+            )
+        );
     }
 
 

--- a/seotoaster_core/application/controllers/SearchController.php
+++ b/seotoaster_core/application/controllers/SearchController.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * SearchController
  *
@@ -12,10 +11,6 @@ class SearchController extends Zend_Controller_Action {
 	public function init() {
 		parent::init();
 		$this->view->websiteUrl = $this->_helper->website->getUrl();
-		$this->_helper->AjaxContext()->addActionContexts(array(
-			'managesearchindex' => 'json'
-		))->initContext('json');
-
 	}
 
 	public function searchAction() {
@@ -78,21 +73,6 @@ class SearchController extends Zend_Controller_Action {
 		}
 	}
 
-	public function managesearchindexAction() {
-		if($this->getRequest()->isPost()) {
-			$doAction = $this->getRequest()->getParam('doaction');
-			switch ($doAction) {
-				case 'renew':
-					Tools_Search_Tools::renewIndex();
-					$this->_helper->response->success($this->_helper->language->translate('Search index is up to date now.'));
-				break;
-				case 'remove':
-					Tools_Search_Tools::removeIndex();
-				break;
-			}
-		}
-	}
-    
     public function complexsearchAction() {
         $this->_helper->layout->disableLayout();
         $this->_helper->viewRenderer->setNoRender(true);
@@ -114,40 +94,6 @@ class SearchController extends Zend_Controller_Action {
         $queryID = md5(serialize($containerContentArray));
         $this->_helper->flashMessenger->addMessage($containerContentArray, $queryID);
 
-        echo json_encode(
-            array(
-                'redirect' => $this->_helper->website->getUrl() . $redirectPage . '?' . http_build_query(
-                            array('queryID' => $queryID)
-                        )
-            )
-        );
-
-        return;
-
-        $containerData = Application_Model_Mappers_ContainerMapper::getInstance()->findByContainerNameWithContent($containerContentArray);
-        $findUrlList = array();
-        if(!empty($containerData)){
-            $pageList = $pageMapper->find($containerData);
-            foreach ($pageList as $page) {
-                $previewImage = '';
-                if ($page->getDraft() == 0) {
-                    if ((bool)$page->getPreviewImage()) {
-                        $previewImage = Tools_Page_Tools::getPreview($page);
-                    }
-                    $resultsHits[] = array(
-                        'pageId'       => $page->getId(),
-                        'url'          => $page->getUrl(),
-                        'h1'           => $page->getH1(),
-                        'teaserText'   => $page->getTeaserText(),
-                        'navName'      => $page->getNavName(),
-                        'previewImage' => $previewImage
-                    );
-                }
-            }
-            $this->_helper->session->searchHits = $resultsHits;
-        }else {
-            $this->_helper->session->searchHits = '{$content:nothingfound}';
-        }
         echo json_encode(
             array(
                 'redirect' => $this->_helper->website->getUrl() . $redirectPage . '?' . http_build_query(

--- a/seotoaster_core/application/forms/PasswordRetrieve.php
+++ b/seotoaster_core/application/forms/PasswordRetrieve.php
@@ -38,7 +38,7 @@ class Application_Form_PasswordRetrieve extends Zend_Form {
 			'main' => array('email')
 		));
 
-		$main = $this->getDisplayGroup('main')
+		$this->getDisplayGroup('main')
 			->setDecorators(array(
 				'FormElements',
 		        'Fieldset',

--- a/seotoaster_core/application/forms/Search.php
+++ b/seotoaster_core/application/forms/Search.php
@@ -7,15 +7,16 @@
  */
 class Application_Form_Search extends Zend_Form {
 
-	protected $_resultsPageId = 0;
+//	protected $_resultsPageId = 0;
 
-	protected $_search        = '';
+    /**
+     * @var string Search term
+     */
+    protected $_search        = '';
 
 	public function init() {
-		$this->setMethod(Zend_Form::METHOD_POST);
-		$this->setAttribs(array(
-			'id'     => 'search-form',
-		));
+        $this->setMethod(Zend_Form::METHOD_GET)
+            ->setAttrib('id', 'search-form');
 
 		$this->addElement(new Zend_Form_Element_Text(array(
 			'id'       => 'search',
@@ -24,20 +25,20 @@ class Application_Form_Search extends Zend_Form {
 			'value'    => $this->_search,
 			'required' => true,
 			'filters'  => array('StringTrim')
-		)));
+        )));
 
-		$this->addElement(new Zend_Form_Element_Hidden(array(
-			'id'       => 'results-page-id',
-			'name'     => 'resultsPageId',
-			'value'    => $this->_resultsPageId
-		)));
+//		$this->addElement(new Zend_Form_Element_Hidden(array(
+//			'id'       => 'results-page-id',
+//			'name'     => 'resultsPageId',
+//			'value'    => $this->_resultsPageId
+//		)));
 
-		$this->addElement(new Zend_Form_Element_Submit(array(
-			'name'  => 'doSearch',
-			'id'    => 'do-search',
-			'value' => 'doSearch',
-			'label' => 'Search'
-		)));
+//		$this->addElement('submit', 'doSearch', array(
+//			'name'  => null,
+//            'id'    => 'do-search',
+//            'value' => 'doSearch',
+//            'label' => 'Search'
+//		));
 
 		$this->_initDecorators();
 	}
@@ -59,19 +60,19 @@ class Application_Form_Search extends Zend_Form {
 			array('HtmlTag', array('tag' => 'p'))
 		));
 		// remove Label decorator from submit button
-		$this->getElement('doSearch')->removeDecorator('Label');
-		$this->getElement('resultsPageId')->removeDecorator('HtmlTag');
+//		$this->getElement('doSearch')->removeDecorator('Label');
+//		$this->getElement('resultsPageId')->removeDecorator('HtmlTag');
 	}
 
-	public function getResultsPageId() {
-		return $this->_resultsPageId;
-	}
-
-	public function setResultsPageId($resultsPageId) {
-		$this->_resultsPageId = $resultsPageId;
-		$this->getElement('resultsPageId')->setValue($resultsPageId);
-		return $this;
-	}
+//	public function getResultsPageId() {
+//		return $this->_resultsPageId;
+//	}
+//
+//	public function setResultsPageId($resultsPageId) {
+//		$this->_resultsPageId = $resultsPageId;
+//		$this->getElement('resultsPageId')->setValue($resultsPageId);
+//		return $this;
+//	}
 
 	public function getSearch() {
 		return $this->_search;

--- a/seotoaster_core/application/forms/Search.php
+++ b/seotoaster_core/application/forms/Search.php
@@ -1,13 +1,10 @@
 <?php
-
 /**
  * Search
  *
  * @author Eugene I. Nezhuta [Seotoaster Dev Team] <eugene@seotoaster.com>
  */
 class Application_Form_Search extends Zend_Form {
-
-//	protected $_resultsPageId = 0;
 
     /**
      * @var string Search term
@@ -18,27 +15,17 @@ class Application_Form_Search extends Zend_Form {
         $this->setMethod(Zend_Form::METHOD_GET)
             ->setAttrib('id', 'search-form');
 
-		$this->addElement(new Zend_Form_Element_Text(array(
-			'id'       => 'search',
-			'name'     => 'search',
-			'label'    => '',
-			'value'    => $this->_search,
-			'required' => true,
-			'filters'  => array('StringTrim')
+        $this->addElement(new Zend_Form_Element_Text(array(
+            'id'       => 'search',
+            'name'     => 'search',
+            'label'    => '',
+            'value'    => $this->_search,
+            'required' => true,
+            'filters'  => array('StringTrim', 'Alnum'),
+            'validators' => array(
+                new Zend_Validate_StringLength(array('min' => 3))
+            )
         )));
-
-//		$this->addElement(new Zend_Form_Element_Hidden(array(
-//			'id'       => 'results-page-id',
-//			'name'     => 'resultsPageId',
-//			'value'    => $this->_resultsPageId
-//		)));
-
-//		$this->addElement('submit', 'doSearch', array(
-//			'name'  => null,
-//            'id'    => 'do-search',
-//            'value' => 'doSearch',
-//            'label' => 'Search'
-//		));
 
 		$this->_initDecorators();
 	}
@@ -59,26 +46,22 @@ class Application_Form_Search extends Zend_Form {
 			'Label',
 			array('HtmlTag', array('tag' => 'p'))
 		));
-		// remove Label decorator from submit button
-//		$this->getElement('doSearch')->removeDecorator('Label');
-//		$this->getElement('resultsPageId')->removeDecorator('HtmlTag');
 	}
 
-//	public function getResultsPageId() {
-//		return $this->_resultsPageId;
-//	}
-//
-//	public function setResultsPageId($resultsPageId) {
-//		$this->_resultsPageId = $resultsPageId;
-//		$this->getElement('resultsPageId')->setValue($resultsPageId);
-//		return $this;
-//	}
-
-	public function getSearch() {
+    /**
+     * Returns current search term
+     * @return string
+     */
+    public function getSearch() {
 		return $this->_search;
 	}
 
-	public function setSearch($search) {
+    /**
+     * Set search term
+     * @param $search Search term
+     * @return $this Instance of Application_Form_Search for chaining
+     */
+    public function setSearch($search) {
 		$this->_search = $search;
 		$this->getElement('search')->setValue($search);
 		return $this;

--- a/seotoaster_core/application/models/Mappers/ContainerMapper.php
+++ b/seotoaster_core/application/models/Mappers/ContainerMapper.php
@@ -96,6 +96,9 @@ class Application_Model_Mappers_ContainerMapper extends Application_Model_Mapper
                 ->select()
                 ->from(array('container'))
                 ->where($where)
+                ->where('content IS NOT NULL')
+                ->where('content != ""')
+                ->order('content ASC')
                 ->group(array('content'));
             return $this->getDbTable()->getAdapter()->fetchAll($select);
         }else{
@@ -105,16 +108,26 @@ class Application_Model_Mappers_ContainerMapper extends Application_Model_Mapper
     
     public function findByContainerNames($prepopNames = array()){
         if(!empty($prepopNames)){
-            $where = '';
-            foreach($prepopNames as $key =>$prepopName){
-                $where .= $this->getDbTable()->getAdapter()->quoteInto('name = ?', $prepopName);
-                if(count($prepopNames) != $key+1){
-                    $where .= ' AND ' . $this->getDbTable()->getAdapter()->quoteInto('container_type = ?', Application_Model_Models_Container::TYPE_PREPOP).' OR ';
-                }else{
-                    $where .= ' AND ' . $this->getDbTable()->getAdapter()->quoteInto('container_type = ?', Application_Model_Models_Container::TYPE_PREPOP);
-                }
-            }
-            return $this->fetchAll($where);
+//            $where = '';
+//            foreach($prepopNames as $key =>$prepopName){
+//                $where .= $this->getDbTable()->getAdapter()->quoteInto('name = ?', $prepopName);
+//                if(count($prepopNames) != $key+1){
+//                    $where .= ' AND ' . $this->getDbTable()->getAdapter()->quoteInto('container_type = ?', Application_Model_Models_Container::TYPE_PREPOP).' OR ';
+//                }else{
+//                    $where .= ' AND ' . $this->getDbTable()->getAdapter()->quoteInto('container_type = ?', Application_Model_Models_Container::TYPE_PREPOP);
+//                }
+//            }
+//            return $this->fetchAll($where);
+            $select = $this->getDbTable()->getAdapter()
+                    ->select()
+                    ->from(array('container'))
+                    ->where('name IN (?)', $prepopNames)
+                    ->where('container_type = ?', Application_Model_Models_Container::TYPE_PREPOP)
+                    ->where('content IS NOT NULL')
+                    ->where('content != ""')
+                    ->order('content ASC');
+//                    ->group(array('content'));
+            return $this->getDbTable()->getAdapter()->fetchAll($select);
         }
     }
     

--- a/seotoaster_core/application/models/Mappers/ContainerMapper.php
+++ b/seotoaster_core/application/models/Mappers/ContainerMapper.php
@@ -1,9 +1,10 @@
 <?php
-
 /**
  * Container mapper
  *
  * @author Seotoaster Dev Team
+ * @method static Application_Model_Mappers_ContainerMapper getInstance() getInstance() Returns an instance of itself
+ * @method Application_Model_DbTable_Container getDbTable() Returns an instance of corresponding DbTable
  */
 class Application_Model_Mappers_ContainerMapper extends Application_Model_Mappers_Abstract {
 
@@ -101,23 +102,13 @@ class Application_Model_Mappers_ContainerMapper extends Application_Model_Mapper
                 ->order('content ASC')
                 ->group(array('content'));
             return $this->getDbTable()->getAdapter()->fetchAll($select);
-        }else{
+        } else {
             return $this->fetchAll($where);
         }
     }
     
     public function findByContainerNames($prepopNames = array()){
         if(!empty($prepopNames)){
-//            $where = '';
-//            foreach($prepopNames as $key =>$prepopName){
-//                $where .= $this->getDbTable()->getAdapter()->quoteInto('name = ?', $prepopName);
-//                if(count($prepopNames) != $key+1){
-//                    $where .= ' AND ' . $this->getDbTable()->getAdapter()->quoteInto('container_type = ?', Application_Model_Models_Container::TYPE_PREPOP).' OR ';
-//                }else{
-//                    $where .= ' AND ' . $this->getDbTable()->getAdapter()->quoteInto('container_type = ?', Application_Model_Models_Container::TYPE_PREPOP);
-//                }
-//            }
-//            return $this->fetchAll($where);
             $select = $this->getDbTable()->getAdapter()
                     ->select()
                     ->from(array('container'))
@@ -126,7 +117,6 @@ class Application_Model_Mappers_ContainerMapper extends Application_Model_Mapper
                     ->where('content IS NOT NULL')
                     ->where('content != ""')
                     ->order('content ASC');
-//                    ->group(array('content'));
             return $this->getDbTable()->getAdapter()->fetchAll($select);
         }
     }


### PR DESCRIPTION
Search form and search widget refactoring:
- Search results now persistant accross page reload. 
- Prepop search uses hard caching (week log) by query ID (hash of search data array). 
- Removed cache index build procedure on empty cache index
- To reindex website separate script should be used: **[reindex.php](https://gist.github.com/PavloKovalov/4ce05d5a38aa03a5dee1)**
